### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,1 @@
 CHANGES.rst merge=union
-
-* text=auto
-* text eol=lf


### PR DESCRIPTION
The current settings modify the zip file as soon as it is downloaded by modifying the content of it (which was also the primary cause of having a corrupted zip file)